### PR TITLE
feat(set): support EX and PX expiry options with validation

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -5,6 +5,7 @@ import (
 	"HelixDB/db"
 	"bytes"
 	"fmt"
+	"time"
 )
 
 var WrongNumberOfArgumentsError = fmt.Errorf("wrong number of arguments")
@@ -25,6 +26,16 @@ func Get(command []string) ([]byte, error) {
 }
 
 func GetValueFromMemory(key string) (string, error) {
+	// Check if the key is expired
+	expirationTime, ok := db.KeyTTL.Load(key)
+	if !ok {
+		return "", fmt.Errorf("key not found")
+	}
+	currentTime := time.Now().UnixMilli()
+	if expirationTime != nil && expirationTime.(int64) < currentTime {
+		return "", fmt.Errorf("key expired")
+	}
+
 	data, ok := db.DB.Load(key)
 	if !ok {
 		return "", fmt.Errorf("key not found")

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,33 +1,45 @@
 package cmd
 
 import (
+	"HelixDB/db"
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 )
 
 // TestGet tests the Get function for
 // all possible valid and invalid inputs
 func TestGet(t *testing.T) {
-	// Prepare
-	// Insert a key in the cache
+	// Prepare: insert a persistent key
 	_, _ = Set([]string{"SET", "tenant", "ACME"})
+	// Prepare: insert a key with a far-future TTL (100 seconds)
+	_, _ = Set([]string{"SET", "active_key", "value1", "EX", "100"})
+	// Prepare: insert a key whose TTL is already in the past (expired).
+	// Set directly to guarantee the expiration timestamp is behind current time.
+	db.DB.Store("expired_key", "value2")
+	db.KeyTTL.Store("expired_key", time.Now().UnixMilli()-1000)
+
 	tests := []struct {
 		command []string
 		want    []byte
 		wantErr error
 	}{
-		// Key exists in the cache
+		// Key exists in the cache (persistent)
 		{[]string{"GET", "tenant"}, []byte("+ACME\r\n"), nil},
 		// Key doesn't exist in the cache
 		{[]string{"GET", "org"}, []byte("$-1\r\n"), nil},
 		// Wrong number of arguments to the GET command
 		{[]string{"GET"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
 		{[]string{"GET", "tenant", "random_arg"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
+		// Key exists with a future TTL — should return value
+		{[]string{"GET", "active_key"}, []byte("+value1\r\n"), nil},
+		// Key exists but TTL already expired — should return nil
+		{[]string{"GET", "expired_key"}, []byte("$-1\r\n"), nil},
 	}
 	for _, test := range tests {
 		if got, gotErr := Get(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {
-			t.Errorf("Get(%v) = %v, %v", test.command, got, gotErr)
+			t.Errorf("Get(%v) = %v, %v; want %v, %v", test.command, got, gotErr, test.want, test.wantErr)
 		}
 	}
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -5,29 +5,105 @@ import (
 	"HelixDB/db"
 	"bytes"
 	"errors"
+	"strconv"
 )
 
 var MissingArgumentsError = errors.New("missing arguments")
 var SyntaxError = errors.New("syntax error")
+var InvalidExpireTimeError = errors.New("invalid expire time in 'set' command")
+
+var SupportedArgs = map[string]bool{
+	common.EX: true,
+	common.PX: true,
+}
 
 func Set(command []string) ([]byte, error) {
 	if len(command) < 3 {
 		return common.RespError("missing arguments"), MissingArgumentsError
 	}
-	if len(command) > 3 {
+	argsMap, err := parseSetArgs(command)
+	if err != nil && errors.Is(err, SyntaxError) {
 		return common.RespError("syntax error"), SyntaxError
+	} else if err != nil {
+		return common.RespError("error"), err
+	}
+	err = processSetArgs(command[1], argsMap)
+	if err != nil && errors.Is(err, InvalidExpireTimeError) {
+		return common.RespError(InvalidExpireTimeError.Error()), InvalidExpireTimeError
+	} else if err != nil {
+		return common.RespError("error"), err
+	}
+	_, err = setValueInMemory(command[1], command[2])
+	if err != nil {
+		return common.RespError("error"), err
 	}
 	var buffer bytes.Buffer
-	_, err := SetValueFromMemory(command[1], command[2])
-	if err != nil {
-		return nil, err
-	}
 	buffer.WriteString("+" + "OK")
 	buffer.WriteString(common.Terminator)
 	return []byte(buffer.String()), nil
 }
 
-func SetValueFromMemory(key string, value string) (bool, error) {
+// parseSetArgs parses the optional arguments after SET key value and returns
+// a map of argument name to its value.
+// EX and PX are mutually exclusive — providing both is a syntax error.
+func parseSetArgs(command []string) (map[string]any, error) {
+	if len(command) == 3 {
+		return nil, nil
+	}
+	extraArgs := command[3:]
+	// Options come in key-value pairs, so extra args must be even in count.
+	if len(extraArgs)%2 != 0 {
+		return nil, SyntaxError
+	}
+	result := make(map[string]any, len(extraArgs)/2)
+	for i := 0; i < len(extraArgs); i += 2 {
+		arg := extraArgs[i]
+		if _, ok := SupportedArgs[arg]; !ok {
+			return nil, SyntaxError
+		}
+		if _, exists := result[arg]; exists {
+			return nil, SyntaxError
+		}
+		result[arg] = extraArgs[i+1]
+	}
+	// EX and PX are mutually exclusive per RESP spec.
+	_, hasEX := result[common.EX]
+	_, hasPX := result[common.PX]
+	if hasEX && hasPX {
+		return nil, SyntaxError
+	}
+	return result, nil
+}
+
+// processSetArgs validates TTL args and stores the expiration time in KeyTTL.
+// If no TTL is provided, the key is stored as persistent (nil expiration).
+func processSetArgs(key string, args map[string]any) error {
+	if ttl, ok := args[common.EX]; ok {
+		seconds, err := strconv.ParseInt(ttl.(string), 10, 64)
+		if err != nil || seconds <= 0 {
+			return InvalidExpireTimeError
+		}
+		ttlInMs := common.SecondsToMilliseconds(seconds)
+		expirationTime := common.GetCurrentTimeInUnixMilli(ttlInMs)
+		db.KeyTTL.Store(key, expirationTime)
+		return nil
+	}
+	if ttl, ok := args[common.PX]; ok {
+		ms, err := strconv.ParseInt(ttl.(string), 10, 64)
+		if err != nil || ms <= 0 {
+			return InvalidExpireTimeError
+		}
+		expirationTime := common.GetCurrentTimeInUnixMilli(ms)
+		db.KeyTTL.Store(key, expirationTime)
+		return nil
+	}
+	// No TTL provided — mark as persistent.
+	db.KeyTTL.Store(key, nil)
+	return nil
+}
+
+// setValueInMemory stores the value in the in-memory DB against the key.
+func setValueInMemory(key string, value string) (bool, error) {
 	db.DB.Store(key, value)
 	return true, nil
 }

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -14,14 +14,35 @@ func TestSet(t *testing.T) {
 		want    []byte
 		wantErr error
 	}{
+		// Basic SET
 		{[]string{"SET", "tenant", "ACME"}, []byte("+OK\r\n"), nil},
+		// Missing key/value
 		{[]string{"SET", "tenant"}, []byte("-missing arguments\r\n"), MissingArgumentsError},
 		{[]string{"SET"}, []byte("-missing arguments\r\n"), MissingArgumentsError},
+		// Unknown option
 		{[]string{"SET", "tenant", "ACME", "asd"}, []byte("-syntax error\r\n"), SyntaxError},
+		// Valid EX
+		{[]string{"SET", "tenant", "ACME", "EX", "10"}, []byte("+OK\r\n"), nil},
+		// Valid PX
+		{[]string{"SET", "tenant", "ACME", "PX", "5000"}, []byte("+OK\r\n"), nil},
+		// EX and PX together — mutually exclusive
+		{[]string{"SET", "tenant", "ACME", "EX", "10", "PX", "5000"}, []byte("-syntax error\r\n"), SyntaxError},
+		// EX with non-numeric value
+		{[]string{"SET", "tenant", "ACME", "EX", "abc"}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
+		// EX with zero — must be positive
+		{[]string{"SET", "tenant", "ACME", "EX", "0"}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
+		// EX with negative value
+		{[]string{"SET", "tenant", "ACME", "EX", "-5"}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
+		// PX with non-numeric value
+		{[]string{"SET", "tenant", "ACME", "PX", "abc"}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
+		// PX with zero — must be positive
+		{[]string{"SET", "tenant", "ACME", "PX", "0"}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
+		// Odd number of extra args (missing value for option)
+		{[]string{"SET", "tenant", "ACME", "EX"}, []byte("-syntax error\r\n"), SyntaxError},
 	}
 	for _, test := range tests {
 		if got, gotErr := Set(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {
-			t.Errorf("Set(%v) = %v, %v", test.command, got, gotErr)
+			t.Errorf("Set(%v) = %v, %v; want %v, %v", test.command, got, gotErr, test.want, test.wantErr)
 		}
 	}
 }

--- a/common/constants.go
+++ b/common/constants.go
@@ -9,3 +9,8 @@ const Command = "COMMAND"
 const Echo = "ECHO"
 const Get = "GET"
 const Set = "SET"
+
+// Command Args
+// Expiration Args
+const EX = "EX"
+const PX = "PX"

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,0 +1,24 @@
+package common
+
+import "time"
+
+// ReverseMap reverses the key-value map to value-key
+func ReverseMap(m map[string]string) map[string]string {
+	n := make(map[string]string, len(m))
+	for k, v := range m {
+		n[v] = k
+	}
+	return n
+}
+
+// SecondsToMilliseconds converts the seconds into milliseconds
+func SecondsToMilliseconds(seconds int64) int64 {
+	return seconds * 1000
+}
+
+// GetCurrentTimeInUnixMilli returns the current time in Unix milliseconds,
+// adjusted by the specified timedelta in milliseconds.
+func GetCurrentTimeInUnixMilli(timedelta int64) int64 {
+	now := time.Now()
+	return now.UnixMilli() + timedelta
+}

--- a/db/store.go
+++ b/db/store.go
@@ -2,4 +2,11 @@ package db
 
 import "sync"
 
+// DB is the main in-memory storage of the cache implementation.
 var DB = sync.Map{}
+
+// KeyTTL stores the key expiration timestamp for each key
+// in EPOCH Unix milliseconds format.
+// A nil value means the key has no expiration (persistent).
+// A key absent from this map has never been SET.
+var KeyTTL = sync.Map{}

--- a/resp/grammar.go
+++ b/resp/grammar.go
@@ -1,15 +1,19 @@
 package resp
 
+import "HelixDB/common"
+
 const SimpleString = "SIMPLE_STRING"
 const SimpleError = "SIMPLE_ERROR"
 const Integer = "INTEGER"
 const BulkString = "BULK_STRING"
 const Array = "ARRAY"
 
-var DataTypes = map[string]string{
+var DataTypeToFirstByteMap = map[string]string{
 	"+": SimpleString,
 	"-": SimpleError,
 	":": Integer,
 	"$": BulkString,
 	"*": Array,
 }
+
+var FirstByteToDataTypeMap = common.ReverseMap(DataTypeToFirstByteMap)

--- a/resp/parser.go
+++ b/resp/parser.go
@@ -22,7 +22,7 @@ func ParseCommand(command []byte) ([]string, error) {
 		return nil, fmt.Errorf("invalid command")
 	}
 	firstByte := string(command[0])
-	dataType, ok := DataTypes[firstByte]
+	dataType, ok := DataTypeToFirstByteMap[firstByte]
 	if !ok {
 		return nil, UnsupportedCommandDataTypeError
 	}


### PR DESCRIPTION
## Implement key expiration for the SET command (closes #31).
  - Add EX (seconds) and PX (milliseconds) options to SET
  - Validate TTL is a positive integer; return InvalidExpireTimeError on zero, negative, or non-numeric values — matching Redis error semantics
  - Reject mutually exclusive EX+PX combination with syntax error
  - Fix parseSetArgs to handle N option pairs instead of hardcoded len==5 check
  - Store expiration as Unix milliseconds in KeyTTL; nil for persistent keys
  - GET checks KeyTTL before returning a value and treats expired keys as missing
  - Add ReverseMap, SecondsToMilliseconds, GetCurrentTimeInUnixMilli helpers in common
  - Rename grammar.go DataTypes → DataTypeToFirstByteMap, add FirstByteToDataTypeMap
  - Expand tests for SET (EX, PX, invalid TTL, conflicting options) and GET (active/expired TTL)