### PR TITLE
feat(expiry): implement active expiration of keys

### DIFF
--- a/db/expiry.go
+++ b/db/expiry.go
@@ -1,0 +1,48 @@
+package db
+
+import (
+	"time"
+)
+
+const (
+	cleanupInterval       = time.Second
+	chunkSize             = 20
+	expiredRatioThreshold = 0.25
+)
+
+// StartActiveExpiry launches a background goroutine that periodically scans
+// KeyTTL for expired keys and removes them from the store.
+// It processes keys in chunks of chunkSize to avoid long pauses.
+// If the expired ratio within a chunk exceeds expiredRatioThreshold, it
+// immediately runs another round rather than waiting for the next tick —
+// this handles bursts of expiring keys efficiently.
+func StartActiveExpiry() {
+	go func() {
+		ticker := time.NewTicker(cleanupInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			for {
+				total, expired := cleanExpiredKeys()
+				if total < chunkSize || float64(expired)/float64(total) < expiredRatioThreshold {
+					break
+				}
+			}
+		}
+	}()
+}
+
+// cleanExpiredKeys scans up to chunkSize keys from KeyTTL, deletes any that
+// have expired, and returns the number of keys scanned and the number deleted.
+func cleanExpiredKeys() (total int, expired int) {
+	now := time.Now().UnixMilli()
+	KeyTTL.Range(func(key, value any) bool {
+		total++
+		if value != nil && value.(int64) < now {
+			KeyTTL.Delete(key)
+			DB.Delete(key)
+			expired++
+		}
+		return total < chunkSize
+	})
+	return
+}

--- a/db/expiry_test.go
+++ b/db/expiry_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCleanExpiredKeys(t *testing.T) {
+	// Clear state before each test run
+	DB.Clear()
+	KeyTTL.Clear()
+
+	now := time.Now().UnixMilli()
+
+	// Expired keys — TTL in the past
+	for _, key := range []string{"exp1", "exp2", "exp3"} {
+		DB.Store(key, "value")
+		KeyTTL.Store(key, now-1000)
+	}
+
+	// Persistent key — nil TTL
+	DB.Store("persistent", "value")
+	KeyTTL.Store("persistent", nil)
+
+	// Active key — TTL in the future
+	DB.Store("active", "value")
+	KeyTTL.Store("active", now+60_000)
+
+	total, expired := cleanExpiredKeys()
+
+	if expired != 3 {
+		t.Errorf("expected 3 expired keys, got %d", expired)
+	}
+	if total != 5 {
+		t.Errorf("expected 5 keys scanned, got %d", total)
+	}
+
+	// Expired keys must be gone from both maps
+	for _, key := range []string{"exp1", "exp2", "exp3"} {
+		if _, ok := DB.Load(key); ok {
+			t.Errorf("expected %q to be deleted from DB", key)
+		}
+		if _, ok := KeyTTL.Load(key); ok {
+			t.Errorf("expected %q to be deleted from KeyTTL", key)
+		}
+	}
+
+	// Persistent and active keys must still exist
+	for _, key := range []string{"persistent", "active"} {
+		if _, ok := DB.Load(key); !ok {
+			t.Errorf("expected %q to still be in DB", key)
+		}
+	}
+}
+
+func TestCleanExpiredKeys_ChunkLimit(t *testing.T) {
+	DB.Clear()
+	KeyTTL.Clear()
+
+	now := time.Now().UnixMilli()
+
+	// Insert more keys than chunkSize, all expired
+	total := chunkSize + 5
+	for i := 0; i < total; i++ {
+		key := string(rune('a' + i))
+		DB.Store(key, "value")
+		KeyTTL.Store(key, now-1000)
+	}
+
+	scanned, _ := cleanExpiredKeys()
+
+	if scanned > chunkSize {
+		t.Errorf("cleanExpiredKeys scanned %d keys, expected at most %d", scanned, chunkSize)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"HelixDB/db"
 	"HelixDB/resp"
 	"fmt"
 	"net"
@@ -14,6 +15,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer l.Close()
+	db.StartActiveExpiry()
 	for {
 		conn, err := l.Accept()
 		if err != nil {


### PR DESCRIPTION
## Implementation
Run a background goroutine that ticks every second and cleans expired keys  in chunks of 20 to avoid long pauses. If the expired ratio within a chunk  exceeds 25%, an additional round runs immediately to handle expiry bursts  without waiting for the next tick.

## Limitations
Known limitations will be handled in #50  and #51 

## Issue:
#45 