### PR TITLE
feat(cmd): implement EXPIRE command

### DIFF
--- a/cmd/expire.go
+++ b/cmd/expire.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"HelixDB/common"
+	"HelixDB/db"
+	"bytes"
+	"errors"
+	"strconv"
+)
+
+var InvalidExpireTimeForExpireError = errors.New("invalid expire time in 'expire' command")
+
+// Expire sets the TTL on an existing key in seconds.
+// Returns 1 if the key exists and the TTL was set, 0 if the key does not exist.
+// RESP integer reply: :1\r\n or :0\r\n
+func Expire(command []string) ([]byte, error) {
+	if len(command) != 3 {
+		return common.RespError("wrong number of arguments"), WrongNumberOfArgumentsError
+	}
+	seconds, err := strconv.ParseInt(command[2], 10, 64)
+	if err != nil || seconds <= 0 {
+		return common.RespError(InvalidExpireTimeForExpireError.Error()), InvalidExpireTimeForExpireError
+	}
+	key := command[1]
+	// Key must already exist in DB.
+	if _, ok := db.DB.Load(key); !ok {
+		return integerReply(0), nil
+	}
+	ttlInMs := common.SecondsToMilliseconds(seconds)
+	expirationTime := common.GetCurrentTimeInUnixMilli(ttlInMs)
+	db.KeyTTL.Store(key, expirationTime)
+	return integerReply(1), nil
+}
+
+func integerReply(n int) []byte {
+	var buffer bytes.Buffer
+	buffer.WriteString(":")
+	buffer.WriteString(strconv.Itoa(n))
+	buffer.WriteString(common.Terminator)
+	return buffer.Bytes()
+}

--- a/cmd/expire_test.go
+++ b/cmd/expire_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestExpire(t *testing.T) {
+	// Prepare: insert a key with no TTL
+	_, _ = Set([]string{"SET", "tenant", "ACME"})
+
+	tests := []struct {
+		command []string
+		want    []byte
+		wantErr error
+	}{
+		// Key exists — TTL set, returns 1
+		{[]string{"EXPIRE", "tenant", "60"}, []byte(":1\r\n"), nil},
+		// Key does not exist — returns 0
+		{[]string{"EXPIRE", "ghost", "60"}, []byte(":0\r\n"), nil},
+		// Wrong number of arguments
+		{[]string{"EXPIRE", "tenant"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
+		{[]string{"EXPIRE"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
+		// Non-numeric seconds
+		{[]string{"EXPIRE", "tenant", "abc"}, []byte("-invalid expire time in 'expire' command\r\n"), InvalidExpireTimeForExpireError},
+		// Zero seconds — must be positive
+		{[]string{"EXPIRE", "tenant", "0"}, []byte("-invalid expire time in 'expire' command\r\n"), InvalidExpireTimeForExpireError},
+		// Negative seconds
+		{[]string{"EXPIRE", "tenant", "-10"}, []byte("-invalid expire time in 'expire' command\r\n"), InvalidExpireTimeForExpireError},
+	}
+	for _, test := range tests {
+		if got, gotErr := Expire(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {
+			t.Errorf("Expire(%v) = %v, %v; want %v, %v", test.command, got, gotErr, test.want, test.wantErr)
+		}
+	}
+}

--- a/common/constants.go
+++ b/common/constants.go
@@ -9,6 +9,7 @@ const Command = "COMMAND"
 const Echo = "ECHO"
 const Get = "GET"
 const Set = "SET"
+const Expire = "EXPIRE"
 
 // Command Args
 // Expiration Args

--- a/exc/command_executor.go
+++ b/exc/command_executor.go
@@ -21,6 +21,8 @@ func ExecuteCommand(command []string) ([]byte, error) {
 		return cmd.Get(command)
 	case common.Set:
 		return cmd.Set(command)
+	case common.Expire:
+		return cmd.Expire(command)
 	}
 	return []byte("-unsupported command\r\n"), UnsupportedCommand
 }


### PR DESCRIPTION
## Implementation
  - Set a TTL in seconds on an already-existing key.
  - Returns :1 if the key exists and TTL was set, :0 if the key does not exist.
  - Validates that seconds is a positive integer, matching Redis error semantics.

## Issue
#46 