### PR TITLE
feat(cmd): implement DEL command and add RespInteger helper

### DIFF
--- a/cmd/del.go
+++ b/cmd/del.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"HelixDB/common"
+	"HelixDB/db"
+)
+
+// Del deletes one or more keys from the store.
+// Keys that do not exist are ignored and not counted.
+// Returns the number of keys that were actually deleted as a RESP integer.
+func Del(command []string) ([]byte, error) {
+	if len(command) < 2 {
+		return common.RespError("wrong number of arguments"), WrongNumberOfArgumentsError
+	}
+	deleted := 0
+	for _, key := range command[1:] {
+		if _, ok := db.DB.Load(key); ok {
+			db.DB.Delete(key)
+			db.KeyTTL.Delete(key)
+			deleted++
+		}
+	}
+	return common.RespInteger(deleted), nil
+}

--- a/cmd/del_test.go
+++ b/cmd/del_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestDel(t *testing.T) {
+	// Prepare: insert keys
+	_, _ = Set([]string{"SET", "key1", "value1"})
+	_, _ = Set([]string{"SET", "key2", "value2"})
+	_, _ = Set([]string{"SET", "key3", "value3"})
+
+	tests := []struct {
+		command []string
+		want    []byte
+		wantErr error
+	}{
+		// Delete a single existing key — returns 1
+		{[]string{"DEL", "key1"}, []byte(":1\r\n"), nil},
+		// Delete a key that does not exist — returns 0
+		{[]string{"DEL", "ghost"}, []byte(":0\r\n"), nil},
+		// Delete multiple keys — key2 exists, key3 exists, ghost does not
+		{[]string{"DEL", "key2", "key3", "ghost"}, []byte(":2\r\n"), nil},
+		// Wrong number of arguments
+		{[]string{"DEL"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
+	}
+	for _, test := range tests {
+		if got, gotErr := Del(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {
+			t.Errorf("Del(%v) = %v, %v; want %v, %v", test.command, got, gotErr, test.want, test.wantErr)
+		}
+	}
+}

--- a/cmd/expire.go
+++ b/cmd/expire.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"HelixDB/common"
 	"HelixDB/db"
-	"bytes"
 	"errors"
 	"strconv"
 )
@@ -24,18 +23,10 @@ func Expire(command []string) ([]byte, error) {
 	key := command[1]
 	// Key must already exist in DB.
 	if _, ok := db.DB.Load(key); !ok {
-		return integerReply(0), nil
+		return common.RespInteger(0), nil
 	}
 	ttlInMs := common.SecondsToMilliseconds(seconds)
 	expirationTime := common.GetCurrentTimeInUnixMilli(ttlInMs)
 	db.KeyTTL.Store(key, expirationTime)
-	return integerReply(1), nil
-}
-
-func integerReply(n int) []byte {
-	var buffer bytes.Buffer
-	buffer.WriteString(":")
-	buffer.WriteString(strconv.Itoa(n))
-	buffer.WriteString(common.Terminator)
-	return buffer.Bytes()
+	return common.RespInteger(1), nil
 }

--- a/common/constants.go
+++ b/common/constants.go
@@ -10,6 +10,7 @@ const Echo = "ECHO"
 const Get = "GET"
 const Set = "SET"
 const Expire = "EXPIRE"
+const Del = "DEL"
 
 // Command Args
 // Expiration Args

--- a/common/resp.go
+++ b/common/resp.go
@@ -1,0 +1,14 @@
+package common
+
+import (
+	"bytes"
+	"strconv"
+)
+
+func RespInteger(n int) []byte {
+	var buffer bytes.Buffer
+	buffer.WriteString(":")
+	buffer.WriteString(strconv.Itoa(n))
+	buffer.WriteString(Terminator)
+	return buffer.Bytes()
+}

--- a/exc/command_executor.go
+++ b/exc/command_executor.go
@@ -23,6 +23,8 @@ func ExecuteCommand(command []string) ([]byte, error) {
 		return cmd.Set(command)
 	case common.Expire:
 		return cmd.Expire(command)
+	case common.Del:
+		return cmd.Del(command)
 	}
 	return []byte("-unsupported command\r\n"), UnsupportedCommand
 }


### PR DESCRIPTION
## Implementation
  - Delete one or more keys in a single call. Keys that do not exist are silently ignored. Returns the count of actually deleted keys as a RESP integer. Also cleans up KeyTTL to avoid stale expiry data.
-  Move the integer RESP serializer out of cmd/expire.go into common/resp.go as RespInteger, so it is available to all commands without cross-command dependencies. 

## Issue
#27 