### PR TITLE
refactor(cmd): replace []string with Cmd struct across the codebase

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -5,10 +5,10 @@ import (
 	"bytes"
 )
 
-func Command(command []string) ([]byte, error) {
+func Command(command common.Cmd) ([]byte, error) {
 	var buffer bytes.Buffer
 	buffer.WriteString("+")
-	if len(command) > 1 && command[1] == "DOCS" {
+	if len(command.Args) > 0 && command.Args[0] == "DOCS" {
 		buffer.WriteString("OK")
 	}
 	buffer.WriteString(common.Terminator)

--- a/cmd/command_test.go
+++ b/cmd/command_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"HelixDB/common"
 	"errors"
 	"reflect"
 	"testing"
@@ -10,17 +11,17 @@ import (
 // all possible valid and invalid inputs
 func TestCommand(t *testing.T) {
 	tests := []struct {
-		command []string
+		command common.Cmd
 		want    []byte
 		wantErr error
 	}{
-		{[]string{"COMMAND"}, []byte("+\r\n"), nil},
-		{[]string{"COMMAND", "DOCS"}, []byte("+OK\r\n"), nil},
-		{[]string{"COMMAND", "DOCS", "random_arg"}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "COMMAND"}, []byte("+\r\n"), nil},
+		{common.Cmd{Name: "COMMAND", Args: []string{"DOCS"}}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "COMMAND", Args: []string{"DOCS", "random_arg"}}, []byte("+OK\r\n"), nil},
 	}
 	for _, test := range tests {
 		if got, gotErr := Command(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {
-			t.Errorf("Command(%v) = %v, %v", test.command, got, gotErr)
+			t.Errorf("Command(%v) = %v, %v; want %v, %v", test.command, got, gotErr, test.want, test.wantErr)
 		}
 	}
 }

--- a/cmd/del.go
+++ b/cmd/del.go
@@ -8,12 +8,12 @@ import (
 // Del deletes one or more keys from the store.
 // Keys that do not exist are ignored and not counted.
 // Returns the number of keys that were actually deleted as a RESP integer.
-func Del(command []string) ([]byte, error) {
-	if len(command) < 2 {
+func Del(command common.Cmd) ([]byte, error) {
+	if len(command.Args) < 1 {
 		return common.RespError("wrong number of arguments"), WrongNumberOfArgumentsError
 	}
 	deleted := 0
-	for _, key := range command[1:] {
+	for _, key := range command.Args {
 		if _, ok := db.DB.Load(key); ok {
 			db.DB.Delete(key)
 			db.KeyTTL.Delete(key)

--- a/cmd/del_test.go
+++ b/cmd/del_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"HelixDB/common"
 	"errors"
 	"reflect"
 	"testing"
@@ -8,23 +9,23 @@ import (
 
 func TestDel(t *testing.T) {
 	// Prepare: insert keys
-	_, _ = Set([]string{"SET", "key1", "value1"})
-	_, _ = Set([]string{"SET", "key2", "value2"})
-	_, _ = Set([]string{"SET", "key3", "value3"})
+	_, _ = Set(common.Cmd{Name: "SET", Args: []string{"key1", "value1"}})
+	_, _ = Set(common.Cmd{Name: "SET", Args: []string{"key2", "value2"}})
+	_, _ = Set(common.Cmd{Name: "SET", Args: []string{"key3", "value3"}})
 
 	tests := []struct {
-		command []string
+		command common.Cmd
 		want    []byte
 		wantErr error
 	}{
 		// Delete a single existing key — returns 1
-		{[]string{"DEL", "key1"}, []byte(":1\r\n"), nil},
+		{common.Cmd{Name: "DEL", Args: []string{"key1"}}, []byte(":1\r\n"), nil},
 		// Delete a key that does not exist — returns 0
-		{[]string{"DEL", "ghost"}, []byte(":0\r\n"), nil},
+		{common.Cmd{Name: "DEL", Args: []string{"ghost"}}, []byte(":0\r\n"), nil},
 		// Delete multiple keys — key2 exists, key3 exists, ghost does not
-		{[]string{"DEL", "key2", "key3", "ghost"}, []byte(":2\r\n"), nil},
+		{common.Cmd{Name: "DEL", Args: []string{"key2", "key3", "ghost"}}, []byte(":2\r\n"), nil},
 		// Wrong number of arguments
-		{[]string{"DEL"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
+		{common.Cmd{Name: "DEL"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
 	}
 	for _, test := range tests {
 		if got, gotErr := Del(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {

--- a/cmd/echo.go
+++ b/cmd/echo.go
@@ -8,14 +8,13 @@ import (
 
 var MessageRequiredError = errors.New("message required")
 
-// Echo is a command that returns the message that
-// passed to it. Message is required for this command
-func Echo(command []string) ([]byte, error) {
-	if len(command) != 2 {
+// Echo returns the message passed to it. Message is required.
+func Echo(command common.Cmd) ([]byte, error) {
+	if len(command.Args) != 1 {
 		return common.RespError("message is required"), MessageRequiredError
 	}
 	var buffer bytes.Buffer
-	buffer.WriteString("+" + command[1])
+	buffer.WriteString("+" + command.Args[0])
 	buffer.WriteString(common.Terminator)
 	return []byte(buffer.String()), nil
 }

--- a/cmd/echo_test.go
+++ b/cmd/echo_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"HelixDB/common"
 	"errors"
 	"reflect"
 	"testing"
@@ -10,16 +11,16 @@ import (
 // all possible valid and invalid inputs
 func TestEcho(t *testing.T) {
 	tests := []struct {
-		command []string
+		command common.Cmd
 		want    []byte
 		wantErr error
 	}{
-		{[]string{"ECHO", "hello"}, []byte("+hello\r\n"), nil},
-		{[]string{"ECHO"}, []byte("-message is required\r\n"), MessageRequiredError},
+		{common.Cmd{Name: "ECHO", Args: []string{"hello"}}, []byte("+hello\r\n"), nil},
+		{common.Cmd{Name: "ECHO"}, []byte("-message is required\r\n"), MessageRequiredError},
 	}
 	for _, test := range tests {
 		if got, gotErr := Echo(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {
-			t.Errorf("Echo(%v) = %v, %v", test.command, got, gotErr)
+			t.Errorf("Echo(%v) = %v, %v; want %v, %v", test.command, got, gotErr, test.want, test.wantErr)
 		}
 	}
 }

--- a/cmd/expire.go
+++ b/cmd/expire.go
@@ -12,15 +12,15 @@ var InvalidExpireTimeForExpireError = errors.New("invalid expire time in 'expire
 // Expire sets the TTL on an existing key in seconds.
 // Returns 1 if the key exists and the TTL was set, 0 if the key does not exist.
 // RESP integer reply: :1\r\n or :0\r\n
-func Expire(command []string) ([]byte, error) {
-	if len(command) != 3 {
+func Expire(command common.Cmd) ([]byte, error) {
+	if len(command.Args) != 2 {
 		return common.RespError("wrong number of arguments"), WrongNumberOfArgumentsError
 	}
-	seconds, err := strconv.ParseInt(command[2], 10, 64)
+	seconds, err := strconv.ParseInt(command.Args[1], 10, 64)
 	if err != nil || seconds <= 0 {
 		return common.RespError(InvalidExpireTimeForExpireError.Error()), InvalidExpireTimeForExpireError
 	}
-	key := command[1]
+	key := command.Args[0]
 	// Key must already exist in DB.
 	if _, ok := db.DB.Load(key); !ok {
 		return common.RespInteger(0), nil

--- a/cmd/expire_test.go
+++ b/cmd/expire_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"HelixDB/common"
 	"errors"
 	"reflect"
 	"testing"
@@ -8,26 +9,26 @@ import (
 
 func TestExpire(t *testing.T) {
 	// Prepare: insert a key with no TTL
-	_, _ = Set([]string{"SET", "tenant", "ACME"})
+	_, _ = Set(common.Cmd{Name: "SET", Args: []string{"tenant", "ACME"}})
 
 	tests := []struct {
-		command []string
+		command common.Cmd
 		want    []byte
 		wantErr error
 	}{
 		// Key exists — TTL set, returns 1
-		{[]string{"EXPIRE", "tenant", "60"}, []byte(":1\r\n"), nil},
+		{common.Cmd{Name: "EXPIRE", Args: []string{"tenant", "60"}}, []byte(":1\r\n"), nil},
 		// Key does not exist — returns 0
-		{[]string{"EXPIRE", "ghost", "60"}, []byte(":0\r\n"), nil},
+		{common.Cmd{Name: "EXPIRE", Args: []string{"ghost", "60"}}, []byte(":0\r\n"), nil},
 		// Wrong number of arguments
-		{[]string{"EXPIRE", "tenant"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
-		{[]string{"EXPIRE"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
+		{common.Cmd{Name: "EXPIRE", Args: []string{"tenant"}}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
+		{common.Cmd{Name: "EXPIRE"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
 		// Non-numeric seconds
-		{[]string{"EXPIRE", "tenant", "abc"}, []byte("-invalid expire time in 'expire' command\r\n"), InvalidExpireTimeForExpireError},
+		{common.Cmd{Name: "EXPIRE", Args: []string{"tenant", "abc"}}, []byte("-invalid expire time in 'expire' command\r\n"), InvalidExpireTimeForExpireError},
 		// Zero seconds — must be positive
-		{[]string{"EXPIRE", "tenant", "0"}, []byte("-invalid expire time in 'expire' command\r\n"), InvalidExpireTimeForExpireError},
+		{common.Cmd{Name: "EXPIRE", Args: []string{"tenant", "0"}}, []byte("-invalid expire time in 'expire' command\r\n"), InvalidExpireTimeForExpireError},
 		// Negative seconds
-		{[]string{"EXPIRE", "tenant", "-10"}, []byte("-invalid expire time in 'expire' command\r\n"), InvalidExpireTimeForExpireError},
+		{common.Cmd{Name: "EXPIRE", Args: []string{"tenant", "-10"}}, []byte("-invalid expire time in 'expire' command\r\n"), InvalidExpireTimeForExpireError},
 	}
 	for _, test := range tests {
 		if got, gotErr := Expire(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -10,12 +10,12 @@ import (
 
 var WrongNumberOfArgumentsError = fmt.Errorf("wrong number of arguments")
 
-func Get(command []string) ([]byte, error) {
-	if len(command) != 2 {
+func Get(command common.Cmd) ([]byte, error) {
+	if len(command.Args) != 1 {
 		return common.RespError("wrong number of arguments"), WrongNumberOfArgumentsError
 	}
 	var buffer bytes.Buffer
-	value, err := GetValueFromMemory(command[1])
+	value, err := GetValueFromMemory(command.Args[0])
 	if err != nil {
 		buffer.WriteString("$" + "-1")
 	} else {

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"HelixDB/common"
 	"HelixDB/db"
 	"errors"
 	"reflect"
@@ -12,30 +13,30 @@ import (
 // all possible valid and invalid inputs
 func TestGet(t *testing.T) {
 	// Prepare: insert a persistent key
-	_, _ = Set([]string{"SET", "tenant", "ACME"})
+	_, _ = Set(common.Cmd{Name: "SET", Args: []string{"tenant", "ACME"}})
 	// Prepare: insert a key with a far-future TTL (100 seconds)
-	_, _ = Set([]string{"SET", "active_key", "value1", "EX", "100"})
+	_, _ = Set(common.Cmd{Name: "SET", Args: []string{"active_key", "value1", "EX", "100"}})
 	// Prepare: insert a key whose TTL is already in the past (expired).
 	// Set directly to guarantee the expiration timestamp is behind current time.
 	db.DB.Store("expired_key", "value2")
 	db.KeyTTL.Store("expired_key", time.Now().UnixMilli()-1000)
 
 	tests := []struct {
-		command []string
+		command common.Cmd
 		want    []byte
 		wantErr error
 	}{
 		// Key exists in the cache (persistent)
-		{[]string{"GET", "tenant"}, []byte("+ACME\r\n"), nil},
+		{common.Cmd{Name: "GET", Args: []string{"tenant"}}, []byte("+ACME\r\n"), nil},
 		// Key doesn't exist in the cache
-		{[]string{"GET", "org"}, []byte("$-1\r\n"), nil},
+		{common.Cmd{Name: "GET", Args: []string{"org"}}, []byte("$-1\r\n"), nil},
 		// Wrong number of arguments to the GET command
-		{[]string{"GET"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
-		{[]string{"GET", "tenant", "random_arg"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
+		{common.Cmd{Name: "GET"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
+		{common.Cmd{Name: "GET", Args: []string{"tenant", "random_arg"}}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
 		// Key exists with a future TTL — should return value
-		{[]string{"GET", "active_key"}, []byte("+value1\r\n"), nil},
+		{common.Cmd{Name: "GET", Args: []string{"active_key"}}, []byte("+value1\r\n"), nil},
 		// Key exists but TTL already expired — should return nil
-		{[]string{"GET", "expired_key"}, []byte("$-1\r\n"), nil},
+		{common.Cmd{Name: "GET", Args: []string{"expired_key"}}, []byte("$-1\r\n"), nil},
 	}
 	for _, test := range tests {
 		if got, gotErr := Get(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -5,16 +5,14 @@ import (
 	"bytes"
 )
 
-// Ping is a command that returns a common response PONG when
-// no any message or input is passed to this command.
-// If any message is passed to this command then it returns
-// that message as output.
-func Ping(command []string) ([]byte, error) {
+// Ping returns PONG when no argument is provided,
+// or echoes back the first argument if one is given.
+func Ping(command common.Cmd) ([]byte, error) {
 	var buffer bytes.Buffer
 	buffer.WriteString("+")
 	message := "PONG"
-	if len(command) > 1 {
-		message = command[1]
+	if len(command.Args) > 0 {
+		message = command.Args[0]
 	}
 	buffer.WriteString(message)
 	buffer.WriteString(common.Terminator)

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"HelixDB/common"
 	"errors"
 	"reflect"
 	"testing"
@@ -10,17 +11,17 @@ import (
 // all possible valid and invalid inputs
 func TestPing(t *testing.T) {
 	tests := []struct {
-		command []string
+		command common.Cmd
 		want    []byte
 		wantErr error
 	}{
-		{[]string{"PING"}, []byte("+PONG\r\n"), nil},
-		{[]string{"PING", "Hello"}, []byte("+Hello\r\n"), nil},
-		{[]string{"PING", "hello"}, []byte("+hello\r\n"), nil},
+		{common.Cmd{Name: "PING"}, []byte("+PONG\r\n"), nil},
+		{common.Cmd{Name: "PING", Args: []string{"Hello"}}, []byte("+Hello\r\n"), nil},
+		{common.Cmd{Name: "PING", Args: []string{"hello"}}, []byte("+hello\r\n"), nil},
 	}
 	for _, test := range tests {
 		if got, gotErr := Ping(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {
-			t.Errorf("Ping(%v) = %v, %v", test.command, got, gotErr)
+			t.Errorf("Ping(%v) = %v, %v; want %v, %v", test.command, got, gotErr, test.want, test.wantErr)
 		}
 	}
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -17,23 +17,23 @@ var SupportedArgs = map[string]bool{
 	common.PX: true,
 }
 
-func Set(command []string) ([]byte, error) {
-	if len(command) < 3 {
+func Set(command common.Cmd) ([]byte, error) {
+	if len(command.Args) < 2 {
 		return common.RespError("missing arguments"), MissingArgumentsError
 	}
-	argsMap, err := parseSetArgs(command)
+	argsMap, err := parseSetArgs(command.Args)
 	if err != nil && errors.Is(err, SyntaxError) {
 		return common.RespError("syntax error"), SyntaxError
 	} else if err != nil {
 		return common.RespError("error"), err
 	}
-	err = processSetArgs(command[1], argsMap)
+	err = processSetArgs(command.Args[0], argsMap)
 	if err != nil && errors.Is(err, InvalidExpireTimeError) {
 		return common.RespError(InvalidExpireTimeError.Error()), InvalidExpireTimeError
 	} else if err != nil {
 		return common.RespError("error"), err
 	}
-	_, err = setValueInMemory(command[1], command[2])
+	_, err = setValueInMemory(command.Args[0], command.Args[1])
 	if err != nil {
 		return common.RespError("error"), err
 	}
@@ -43,14 +43,14 @@ func Set(command []string) ([]byte, error) {
 	return []byte(buffer.String()), nil
 }
 
-// parseSetArgs parses the optional arguments after SET key value and returns
+// parseSetArgs parses the optional arguments after key and value and returns
 // a map of argument name to its value.
 // EX and PX are mutually exclusive — providing both is a syntax error.
-func parseSetArgs(command []string) (map[string]any, error) {
-	if len(command) == 3 {
+func parseSetArgs(args []string) (map[string]any, error) {
+	if len(args) == 2 {
 		return nil, nil
 	}
-	extraArgs := command[3:]
+	extraArgs := args[2:]
 	// Options come in key-value pairs, so extra args must be even in count.
 	if len(extraArgs)%2 != 0 {
 		return nil, SyntaxError

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"HelixDB/common"
 	"errors"
 	"reflect"
 	"testing"
@@ -10,35 +11,35 @@ import (
 // all possible valid and invalid inputs
 func TestSet(t *testing.T) {
 	tests := []struct {
-		command []string
+		command common.Cmd
 		want    []byte
 		wantErr error
 	}{
 		// Basic SET
-		{[]string{"SET", "tenant", "ACME"}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME"}}, []byte("+OK\r\n"), nil},
 		// Missing key/value
-		{[]string{"SET", "tenant"}, []byte("-missing arguments\r\n"), MissingArgumentsError},
-		{[]string{"SET"}, []byte("-missing arguments\r\n"), MissingArgumentsError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant"}}, []byte("-missing arguments\r\n"), MissingArgumentsError},
+		{common.Cmd{Name: "SET"}, []byte("-missing arguments\r\n"), MissingArgumentsError},
 		// Unknown option
-		{[]string{"SET", "tenant", "ACME", "asd"}, []byte("-syntax error\r\n"), SyntaxError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "asd"}}, []byte("-syntax error\r\n"), SyntaxError},
 		// Valid EX
-		{[]string{"SET", "tenant", "ACME", "EX", "10"}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "EX", "10"}}, []byte("+OK\r\n"), nil},
 		// Valid PX
-		{[]string{"SET", "tenant", "ACME", "PX", "5000"}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "PX", "5000"}}, []byte("+OK\r\n"), nil},
 		// EX and PX together — mutually exclusive
-		{[]string{"SET", "tenant", "ACME", "EX", "10", "PX", "5000"}, []byte("-syntax error\r\n"), SyntaxError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "EX", "10", "PX", "5000"}}, []byte("-syntax error\r\n"), SyntaxError},
 		// EX with non-numeric value
-		{[]string{"SET", "tenant", "ACME", "EX", "abc"}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "EX", "abc"}}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
 		// EX with zero — must be positive
-		{[]string{"SET", "tenant", "ACME", "EX", "0"}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "EX", "0"}}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
 		// EX with negative value
-		{[]string{"SET", "tenant", "ACME", "EX", "-5"}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "EX", "-5"}}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
 		// PX with non-numeric value
-		{[]string{"SET", "tenant", "ACME", "PX", "abc"}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "PX", "abc"}}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
 		// PX with zero — must be positive
-		{[]string{"SET", "tenant", "ACME", "PX", "0"}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "PX", "0"}}, []byte("-invalid expire time in 'set' command\r\n"), InvalidExpireTimeError},
 		// Odd number of extra args (missing value for option)
-		{[]string{"SET", "tenant", "ACME", "EX"}, []byte("-syntax error\r\n"), SyntaxError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "EX"}}, []byte("-syntax error\r\n"), SyntaxError},
 	}
 	for _, test := range tests {
 		if got, gotErr := Set(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {

--- a/common/types.go
+++ b/common/types.go
@@ -1,0 +1,9 @@
+package common
+
+// Cmd represents a parsed client command.
+// Name is the uppercased command name (e.g. "SET").
+// Args contains the positional arguments following the command name.
+type Cmd struct {
+	Name string
+	Args []string
+}

--- a/exc/command_executor.go
+++ b/exc/command_executor.go
@@ -4,13 +4,12 @@ import (
 	"HelixDB/cmd"
 	"HelixDB/common"
 	"errors"
-	"strings"
 )
 
 var UnsupportedCommand = errors.New("unsupported command")
 
-func ExecuteCommand(command []string) ([]byte, error) {
-	switch strings.ToUpper(command[0]) {
+func ExecuteCommand(command common.Cmd) ([]byte, error) {
+	switch command.Name {
 	case common.Ping:
 		return cmd.Ping(command)
 	case common.Command:

--- a/exc/command_executor_test.go
+++ b/exc/command_executor_test.go
@@ -2,6 +2,7 @@ package exc
 
 import (
 	"HelixDB/cmd"
+	"HelixDB/common"
 	"errors"
 	"fmt"
 	"reflect"
@@ -12,36 +13,36 @@ import (
 // all possible valid and invalid inputs
 func TestExecuteCommand(t *testing.T) {
 	tests := []struct {
-		command []string
+		command common.Cmd
 		want    []byte
 		wantErr error
 	}{
 		// COMMAND command
-		{[]string{"COMMAND"}, []byte("+\r\n"), nil},
-		{[]string{"COMMAND", "DOCS"}, []byte("+OK\r\n"), nil},
-		{[]string{"COMMAND", "DOCS", "random_arg"}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "COMMAND"}, []byte("+\r\n"), nil},
+		{common.Cmd{Name: "COMMAND", Args: []string{"DOCS"}}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "COMMAND", Args: []string{"DOCS", "random_arg"}}, []byte("+OK\r\n"), nil},
 		// PING command
-		{[]string{"PING"}, []byte("+PONG\r\n"), nil},
-		{[]string{"PING", "Hello"}, []byte("+Hello\r\n"), nil},
+		{common.Cmd{Name: "PING"}, []byte("+PONG\r\n"), nil},
+		{common.Cmd{Name: "PING", Args: []string{"Hello"}}, []byte("+Hello\r\n"), nil},
 		// ECHO command
-		{[]string{"ECHO", "hello"}, []byte("+hello\r\n"), nil},
-		{[]string{"ECHO"}, []byte("-message is required\r\n"), cmd.MessageRequiredError},
+		{common.Cmd{Name: "ECHO", Args: []string{"hello"}}, []byte("+hello\r\n"), nil},
+		{common.Cmd{Name: "ECHO"}, []byte("-message is required\r\n"), cmd.MessageRequiredError},
 		// SET command
-		{[]string{"SET", "tenant", "ACME"}, []byte("+OK\r\n"), nil},
-		{[]string{"SET", "tenant"}, []byte("-missing arguments\r\n"), cmd.MissingArgumentsError},
-		{[]string{"SET"}, []byte("-missing arguments\r\n"), cmd.MissingArgumentsError},
-		{[]string{"SET", "tenant", "ACME", "asd"}, []byte("-syntax error\r\n"), cmd.SyntaxError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME"}}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "SET", Args: []string{"tenant"}}, []byte("-missing arguments\r\n"), cmd.MissingArgumentsError},
+		{common.Cmd{Name: "SET"}, []byte("-missing arguments\r\n"), cmd.MissingArgumentsError},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "asd"}}, []byte("-syntax error\r\n"), cmd.SyntaxError},
 		// GET command
-		{[]string{"GET", "tenant"}, []byte("+ACME\r\n"), nil},
-		{[]string{"GET", "org"}, []byte("$-1\r\n"), nil},
-		{[]string{"GET"}, []byte("-wrong number of arguments\r\n"), cmd.WrongNumberOfArgumentsError},
-		{[]string{"GET", "tenant", "random_arg"}, []byte("-wrong number of arguments\r\n"), cmd.WrongNumberOfArgumentsError},
+		{common.Cmd{Name: "GET", Args: []string{"tenant"}}, []byte("+ACME\r\n"), nil},
+		{common.Cmd{Name: "GET", Args: []string{"org"}}, []byte("$-1\r\n"), nil},
+		{common.Cmd{Name: "GET"}, []byte("-wrong number of arguments\r\n"), cmd.WrongNumberOfArgumentsError},
+		{common.Cmd{Name: "GET", Args: []string{"tenant", "random_arg"}}, []byte("-wrong number of arguments\r\n"), cmd.WrongNumberOfArgumentsError},
 		// Unsupported/Invalid command
-		{[]string{"UNSUPPORTED"}, []byte("-unsupported command\r\n"), UnsupportedCommand},
+		{common.Cmd{Name: "UNSUPPORTED"}, []byte("-unsupported command\r\n"), UnsupportedCommand},
 	}
 	for _, test := range tests {
 		if got, gotErr := ExecuteCommand(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {
-			t.Errorf("ExecuteCommand(%v) = %v, %v", test.command, got, gotErr)
+			t.Errorf("ExecuteCommand(%v) = %v, %v; want %v, %v", test.command, got, gotErr, test.want, test.wantErr)
 		}
 	}
 }
@@ -50,20 +51,19 @@ func TestExecuteCommand(t *testing.T) {
 // against huge number of executions
 func BenchmarkExecuteCommand(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, err := ExecuteCommand([]string{"PING"})
+		_, err := ExecuteCommand(common.Cmd{Name: "PING"})
 		if err != nil {
 			continue
 		}
 	}
 }
 
-// ExampleExecuteCommand is an example function. It serves as a
-// documentation function.
+// ExampleExecuteCommand is an example function. It serves as a documentation function.
 func ExampleExecuteCommand() {
-	fmt.Println(ExecuteCommand([]string{"PING"}))
-	fmt.Println(ExecuteCommand([]string{"ECHO", "hello"}))
-	fmt.Println(ExecuteCommand([]string{"SET", "tenant", "ACME"}))
-	fmt.Println(ExecuteCommand([]string{"GET", "tenant"}))
+	fmt.Println(ExecuteCommand(common.Cmd{Name: "PING"}))
+	fmt.Println(ExecuteCommand(common.Cmd{Name: "ECHO", Args: []string{"hello"}}))
+	fmt.Println(ExecuteCommand(common.Cmd{Name: "SET", Args: []string{"tenant", "ACME"}}))
+	fmt.Println(ExecuteCommand(common.Cmd{Name: "GET", Args: []string{"tenant"}}))
 	// Output:
 	// [43 80 79 78 71 13 10] <nil>
 	// [43 104 101 108 108 111 13 10] <nil>

--- a/resp/parser.go
+++ b/resp/parser.go
@@ -9,41 +9,41 @@ import (
 
 var UnsupportedCommandDataTypeError = errors.New("unsupported command datatype")
 
-// ParseCommand parses the command and returns it as a slice of string.
-// ParseCommand parses the commands of type Array.
-//
-// Note:
-// Simple String cannot be accepted as a command and is only for command replies.
-func ParseCommand(command []byte) ([]string, error) {
+// ParseCommand parses the raw RESP bytes and returns a Cmd.
+// Only Array type commands are accepted; Simple Strings are for replies only.
+func ParseCommand(command []byte) (common.Cmd, error) {
 	if command == nil {
-		return nil, nil
+		return common.Cmd{}, nil
 	}
 	if !isValidCommand(command) {
-		return nil, fmt.Errorf("invalid command")
+		return common.Cmd{}, fmt.Errorf("invalid command")
 	}
 	firstByte := string(command[0])
 	dataType, ok := DataTypeToFirstByteMap[firstByte]
 	if !ok {
-		return nil, UnsupportedCommandDataTypeError
+		return common.Cmd{}, UnsupportedCommandDataTypeError
 	}
 	data := strings.Split(string(command), common.Terminator)
 	if dataType == Array {
 		return parseArray(data)
 	}
-	return nil, nil
+	return common.Cmd{}, nil
 }
 
 func isValidCommand(command []byte) bool {
-	if command == nil {
-		return false
-	}
-	return true
+	return command != nil
 }
 
-func parseArray(data []string) ([]string, error) {
-	var value []string
+func parseArray(data []string) (common.Cmd, error) {
+	var parts []string
 	for i := 2; i < len(data); i += 2 {
-		value = append(value, data[i])
+		parts = append(parts, data[i])
 	}
-	return value, nil
+	if len(parts) == 0 {
+		return common.Cmd{}, fmt.Errorf("empty command")
+	}
+	return common.Cmd{
+		Name: strings.ToUpper(parts[0]),
+		Args: parts[1:],
+	}, nil
 }

--- a/resp/parser_test.go
+++ b/resp/parser_test.go
@@ -1,6 +1,7 @@
 package resp
 
 import (
+	"HelixDB/common"
 	"errors"
 	"fmt"
 	"reflect"
@@ -12,30 +13,30 @@ import (
 func TestParseCommand(t *testing.T) {
 	tests := []struct {
 		command []byte
-		want    []string
+		want    common.Cmd
 		wantErr error
 	}{
-		// Simple String cannot be accepted as a command.
-		{[]byte("+OK\r\n"), nil, nil},
-		// Array type command
-		{[]byte("*1\r\n$4\r\nPING\r\n"), []string{"PING"}, nil},
-		{[]byte("*1\r\n$4\r\nECHO\r\n"), []string{"ECHO"}, nil},
-		{[]byte("*1\r\n$4\r\nECHO\r\n$2\r\nhi\r\n"), []string{"ECHO", "hi"}, nil},
+		// Simple String cannot be accepted as a command — returns zero-value Cmd
+		{[]byte("+OK\r\n"), common.Cmd{}, nil},
+		// Array type commands
+		{[]byte("*1\r\n$4\r\nPING\r\n"), common.Cmd{Name: "PING", Args: []string{}}, nil},
+		{[]byte("*1\r\n$4\r\nECHO\r\n"), common.Cmd{Name: "ECHO", Args: []string{}}, nil},
+		{[]byte("*1\r\n$4\r\nECHO\r\n$2\r\nhi\r\n"), common.Cmd{Name: "ECHO", Args: []string{"hi"}}, nil},
 		// Array type command with multiple args
-		{[]byte("*1\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n"), []string{"SET", "key", "value"}, nil},
+		{[]byte("*1\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n"), common.Cmd{Name: "SET", Args: []string{"key", "value"}}, nil},
 		// Invalid commands
-		{nil, nil, nil},
+		{nil, common.Cmd{}, nil},
 		// Unsupported datatype
-		{[]byte("%1\r\n$4\r\nECHO\r\n$2\r\nhi\r\n"), nil, UnsupportedCommandDataTypeError},
+		{[]byte("%1\r\n$4\r\nECHO\r\n$2\r\nhi\r\n"), common.Cmd{}, UnsupportedCommandDataTypeError},
 	}
 	for _, test := range tests {
 		if got, gotErr := ParseCommand(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {
-			t.Errorf("ParseCommand(%v) = %v, %v", test.command, got, gotErr)
+			t.Errorf("ParseCommand(%v) = %v, %v; want %v, %v", test.command, got, gotErr, test.want, test.wantErr)
 		}
 	}
 }
 
-// BenchmarkGetDivision benchmarks the ParseCommand function
+// BenchmarkParseCommand benchmarks the ParseCommand function
 // against huge number of executions
 func BenchmarkParseCommand(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -46,12 +47,11 @@ func BenchmarkParseCommand(b *testing.B) {
 	}
 }
 
-// ExampleParseCommand is an example function. It serves as a
-// documentation function.
+// ExampleParseCommand is an example function. It serves as a documentation function.
 func ExampleParseCommand() {
 	fmt.Println(ParseCommand([]byte("*1\r\n$4\r\nPING\r\n")))
 	fmt.Println(ParseCommand([]byte("*1\r\n$4\r\nECHO\r\n$2\r\nhi\r\n")))
 	// Output:
-	// [PING] <nil>
-	// [ECHO hi] <nil>
+	// {PING []} <nil>
+	// {ECHO [hi]} <nil>
 }

--- a/resp/request.go
+++ b/resp/request.go
@@ -6,14 +6,15 @@ import (
 )
 
 func PerformRequest(buffer []byte, conn net.Conn) {
-	// Todo: This parse command function will return the command, and it's args
-	//  Using this command name and args, we need to execute the command
-	commandData, err := ParseCommand(buffer)
+	command, err := ParseCommand(buffer)
 	if err != nil {
 		ReplyCommand([]byte("-unsupported command\r\n"), conn)
 		return
 	}
-	reply, err := exc.ExecuteCommand(commandData)
+	if command.Name == "" {
+		return
+	}
+	reply, err := exc.ExecuteCommand(command)
 	if err != nil {
 		ReplyCommand([]byte("-error executing the command\r\n"), conn)
 		return


### PR DESCRIPTION
## Implementation
  - Introduce common.Cmd{Name, Args} to cleanly separate the command name from its arguments. ParseCommand now returns common.Cmd with Name uppercased at parse time, removing the ToUpper call from the executor.
  - All command handlers receive common.Cmd and access Args directly with no index offset. Adds a guard in PerformRequest for zero-value Cmd to safely handle SimpleString and nil inputs.

## Issue
#18 