### PR TITLE
feat(cmd): implement KEYS command and fix RESP response types

### DIFF
--- a/cmd/echo.go
+++ b/cmd/echo.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"HelixDB/common"
-	"bytes"
 	"errors"
 )
 
@@ -13,8 +12,5 @@ func Echo(command common.Cmd) ([]byte, error) {
 	if len(command.Args) != 1 {
 		return common.RespError("message is required"), MessageRequiredError
 	}
-	var buffer bytes.Buffer
-	buffer.WriteString("+" + command.Args[0])
-	buffer.WriteString(common.Terminator)
-	return []byte(buffer.String()), nil
+	return common.RespBulkString(command.Args[0]), nil
 }

--- a/cmd/echo_test.go
+++ b/cmd/echo_test.go
@@ -15,7 +15,7 @@ func TestEcho(t *testing.T) {
 		want    []byte
 		wantErr error
 	}{
-		{common.Cmd{Name: "ECHO", Args: []string{"hello"}}, []byte("+hello\r\n"), nil},
+		{common.Cmd{Name: "ECHO", Args: []string{"hello"}}, []byte("$5\r\nhello\r\n"), nil},
 		{common.Cmd{Name: "ECHO"}, []byte("-message is required\r\n"), MessageRequiredError},
 	}
 	for _, test := range tests {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"HelixDB/common"
 	"HelixDB/db"
-	"bytes"
 	"fmt"
 	"time"
 )
@@ -14,15 +13,11 @@ func Get(command common.Cmd) ([]byte, error) {
 	if len(command.Args) != 1 {
 		return common.RespError("wrong number of arguments"), WrongNumberOfArgumentsError
 	}
-	var buffer bytes.Buffer
 	value, err := GetValueFromMemory(command.Args[0])
 	if err != nil {
-		buffer.WriteString("$" + "-1")
-	} else {
-		buffer.WriteString("+" + value)
+		return common.RespNullBulkString(), nil
 	}
-	buffer.WriteString(common.Terminator)
-	return []byte(buffer.String()), nil
+	return common.RespBulkString(value), nil
 }
 
 func GetValueFromMemory(key string) (string, error) {

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -27,14 +27,14 @@ func TestGet(t *testing.T) {
 		wantErr error
 	}{
 		// Key exists in the cache (persistent)
-		{common.Cmd{Name: "GET", Args: []string{"tenant"}}, []byte("+ACME\r\n"), nil},
+		{common.Cmd{Name: "GET", Args: []string{"tenant"}}, []byte("$4\r\nACME\r\n"), nil},
 		// Key doesn't exist in the cache
 		{common.Cmd{Name: "GET", Args: []string{"org"}}, []byte("$-1\r\n"), nil},
 		// Wrong number of arguments to the GET command
 		{common.Cmd{Name: "GET"}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
 		{common.Cmd{Name: "GET", Args: []string{"tenant", "random_arg"}}, []byte("-wrong number of arguments\r\n"), WrongNumberOfArgumentsError},
 		// Key exists with a future TTL — should return value
-		{common.Cmd{Name: "GET", Args: []string{"active_key"}}, []byte("+value1\r\n"), nil},
+		{common.Cmd{Name: "GET", Args: []string{"active_key"}}, []byte("$6\r\nvalue1\r\n"), nil},
 		// Key exists but TTL already expired — should return nil
 		{common.Cmd{Name: "GET", Args: []string{"expired_key"}}, []byte("$-1\r\n"), nil},
 	}

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"HelixDB/common"
+	"HelixDB/db"
+	"path"
+	"time"
+)
+
+// Keys returns all keys in the store that match the given glob-style pattern.
+// Expired keys are excluded. Returns a RESP bulk string array.
+//
+// Supported pattern syntax (via path.Match):
+//   - * matches any sequence of characters (not including /)
+//   - ? matches any single character (not including /)
+//   - [abc] matches any character in the set
+//
+// Note: keys containing '/' are not fully supported with wildcard patterns.
+func Keys(command common.Cmd) ([]byte, error) {
+	if len(command.Args) != 1 {
+		return common.RespError("wrong number of arguments"), WrongNumberOfArgumentsError
+	}
+	pattern := command.Args[0]
+	// Validate pattern before scanning — path.Match returns ErrBadPattern for invalid syntax.
+	if _, err := path.Match(pattern, ""); err != nil {
+		return common.RespError("invalid pattern"), SyntaxError
+	}
+
+	now := time.Now().UnixMilli()
+	var keys []string
+	db.DB.Range(func(k, _ any) bool {
+		key := k.(string)
+		// Skip expired keys
+		if expirationTime, ok := db.KeyTTL.Load(key); ok {
+			if expirationTime != nil && expirationTime.(int64) < now {
+				return true
+			}
+		}
+		matched, _ := path.Match(pattern, key)
+		if matched {
+			keys = append(keys, key)
+		}
+		return true
+	})
+	return common.RespBulkStringArray(keys), nil
+}

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -27,17 +27,22 @@ func Keys(command common.Cmd) ([]byte, error) {
 	}
 
 	now := time.Now().UnixMilli()
+	matchAll := pattern == "*"
 	var keys []string
-	db.DB.Range(func(k, _ any) bool {
-		key := k.(string)
+
+	// Iterate KeyTTL as the single source of truth for all live keys,
+	// avoiding a separate DB lookup per key.
+	db.KeyTTL.Range(func(k, value any) bool {
 		// Skip expired keys
-		if expirationTime, ok := db.KeyTTL.Load(key); ok {
-			if expirationTime != nil && expirationTime.(int64) < now {
-				return true
-			}
+		if value != nil && value.(int64) < now {
+			return true
 		}
-		matched, _ := path.Match(pattern, key)
-		if matched {
+		key := k.(string)
+		if matchAll {
+			keys = append(keys, key)
+			return true
+		}
+		if matched, _ := path.Match(pattern, key); matched {
 			keys = append(keys, key)
 		}
 		return true

--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -63,10 +63,10 @@ func TestKeys(t *testing.T) {
 	}
 }
 
-// matchBulkStringArray checks that a RESP bulk string array response
-// contains exactly the expected keys, regardless of order.
-func matchBulkStringArray(resp []byte, expectedKeys []string) bool {
-	lines := strings.Split(string(resp), "\r\n")
+// matchBulkStringArray checks that a command response bytes
+// contain exactly the expected keys as bulk strings, regardless of order.
+func matchBulkStringArray(rawResponse []byte, expectedKeys []string) bool {
+	lines := strings.Split(string(rawResponse), "\r\n")
 	if len(lines) == 0 {
 		return false
 	}

--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"HelixDB/common"
+	"HelixDB/db"
+	"bytes"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestKeys(t *testing.T) {
+	// Clear state
+	db.DB.Clear()
+	db.KeyTTL.Clear()
+
+	// Persistent keys
+	_, _ = Set(common.Cmd{Name: "SET", Args: []string{"hello", "1"}})
+	_, _ = Set(common.Cmd{Name: "SET", Args: []string{"hallo", "2"}})
+	_, _ = Set(common.Cmd{Name: "SET", Args: []string{"hxllo", "3"}})
+	_, _ = Set(common.Cmd{Name: "SET", Args: []string{"world", "4"}})
+
+	// Expired key — should not appear in results
+	db.DB.Store("expired", "x")
+	db.KeyTTL.Store("expired", time.Now().UnixMilli()-1000)
+
+	tests := []struct {
+		command      common.Cmd
+		wantKeys     []string // expected keys, order-independent
+		wantErr      error
+	}{
+		// Match all keys
+		{common.Cmd{Name: "KEYS", Args: []string{"*"}}, []string{"hello", "hallo", "hxllo", "world"}, nil},
+		// ? matches single character
+		{common.Cmd{Name: "KEYS", Args: []string{"h?llo"}}, []string{"hello", "hallo", "hxllo"}, nil},
+		// Exact match
+		{common.Cmd{Name: "KEYS", Args: []string{"world"}}, []string{"world"}, nil},
+		// No match
+		{common.Cmd{Name: "KEYS", Args: []string{"nomatch"}}, []string{}, nil},
+		// Character class
+		{common.Cmd{Name: "KEYS", Args: []string{"h[ae]llo"}}, []string{"hello", "hallo"}, nil},
+		// Wrong number of arguments
+		{common.Cmd{Name: "KEYS"}, nil, WrongNumberOfArgumentsError},
+		{common.Cmd{Name: "KEYS", Args: []string{"*", "extra"}}, nil, WrongNumberOfArgumentsError},
+		// Invalid pattern — unclosed bracket
+		{common.Cmd{Name: "KEYS", Args: []string{"["}}, nil, SyntaxError},
+	}
+
+	for _, test := range tests {
+		got, gotErr := Keys(test.command)
+		if !errors.Is(gotErr, test.wantErr) {
+			t.Errorf("Keys(%v) error = %v; want %v", test.command, gotErr, test.wantErr)
+			continue
+		}
+		if test.wantErr != nil {
+			continue
+		}
+		if !matchBulkStringArray(got, test.wantKeys) {
+			t.Errorf("Keys(%v) = %s; want keys %v", test.command, got, test.wantKeys)
+		}
+	}
+}
+
+// matchBulkStringArray checks that a RESP bulk string array response
+// contains exactly the expected keys, regardless of order.
+func matchBulkStringArray(resp []byte, expectedKeys []string) bool {
+	lines := strings.Split(string(resp), "\r\n")
+	if len(lines) == 0 {
+		return false
+	}
+	// Extract values from bulk string entries (lines starting with $)
+	var gotKeys []string
+	for i, line := range lines {
+		if len(line) > 0 && line[0] == '$' && i+1 < len(lines) {
+			gotKeys = append(gotKeys, lines[i+1])
+		}
+	}
+	if len(gotKeys) != len(expectedKeys) {
+		return false
+	}
+	sort.Strings(gotKeys)
+	sort.Strings(expectedKeys)
+	return bytes.Equal([]byte(strings.Join(gotKeys, ",")), []byte(strings.Join(expectedKeys, ",")))
+}

--- a/common/constants.go
+++ b/common/constants.go
@@ -11,6 +11,7 @@ const Get = "GET"
 const Set = "SET"
 const Expire = "EXPIRE"
 const Del = "DEL"
+const Keys = "KEYS"
 
 // Command Args
 // Expiration Args

--- a/common/resp.go
+++ b/common/resp.go
@@ -2,8 +2,40 @@ package common
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 )
+
+// RespBulkString formats a string value as a RESP bulk string: $len\r\nvalue\r\n
+func RespBulkString(value string) []byte {
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("$%d", len(value)))
+	buffer.WriteString(Terminator)
+	buffer.WriteString(value)
+	buffer.WriteString(Terminator)
+	return buffer.Bytes()
+}
+
+// RespNullBulkString returns the RESP null bulk string: $-1\r\n
+// Used when a key does not exist or has expired.
+func RespNullBulkString() []byte {
+	return []byte("$-1" + Terminator)
+}
+
+// RespBulkStringArray formats a slice of strings as a RESP array of bulk strings.
+// An empty slice returns *0\r\n (empty array).
+func RespBulkStringArray(items []string) []byte {
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("*%d", len(items)))
+	buffer.WriteString(Terminator)
+	for _, item := range items {
+		buffer.WriteString(fmt.Sprintf("$%d", len(item)))
+		buffer.WriteString(Terminator)
+		buffer.WriteString(item)
+		buffer.WriteString(Terminator)
+	}
+	return buffer.Bytes()
+}
 
 func RespInteger(n int) []byte {
 	var buffer bytes.Buffer

--- a/exc/command_executor.go
+++ b/exc/command_executor.go
@@ -24,6 +24,8 @@ func ExecuteCommand(command common.Cmd) ([]byte, error) {
 		return cmd.Expire(command)
 	case common.Del:
 		return cmd.Del(command)
+	case common.Keys:
+		return cmd.Keys(command)
 	}
 	return []byte("-unsupported command\r\n"), UnsupportedCommand
 }

--- a/exc/command_executor_test.go
+++ b/exc/command_executor_test.go
@@ -25,7 +25,7 @@ func TestExecuteCommand(t *testing.T) {
 		{common.Cmd{Name: "PING"}, []byte("+PONG\r\n"), nil},
 		{common.Cmd{Name: "PING", Args: []string{"Hello"}}, []byte("+Hello\r\n"), nil},
 		// ECHO command
-		{common.Cmd{Name: "ECHO", Args: []string{"hello"}}, []byte("+hello\r\n"), nil},
+		{common.Cmd{Name: "ECHO", Args: []string{"hello"}}, []byte("$5\r\nhello\r\n"), nil},
 		{common.Cmd{Name: "ECHO"}, []byte("-message is required\r\n"), cmd.MessageRequiredError},
 		// SET command
 		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME"}}, []byte("+OK\r\n"), nil},
@@ -33,7 +33,7 @@ func TestExecuteCommand(t *testing.T) {
 		{common.Cmd{Name: "SET"}, []byte("-missing arguments\r\n"), cmd.MissingArgumentsError},
 		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "asd"}}, []byte("-syntax error\r\n"), cmd.SyntaxError},
 		// GET command
-		{common.Cmd{Name: "GET", Args: []string{"tenant"}}, []byte("+ACME\r\n"), nil},
+		{common.Cmd{Name: "GET", Args: []string{"tenant"}}, []byte("$4\r\nACME\r\n"), nil},
 		{common.Cmd{Name: "GET", Args: []string{"org"}}, []byte("$-1\r\n"), nil},
 		{common.Cmd{Name: "GET"}, []byte("-wrong number of arguments\r\n"), cmd.WrongNumberOfArgumentsError},
 		{common.Cmd{Name: "GET", Args: []string{"tenant", "random_arg"}}, []byte("-wrong number of arguments\r\n"), cmd.WrongNumberOfArgumentsError},
@@ -66,7 +66,7 @@ func ExampleExecuteCommand() {
 	fmt.Println(ExecuteCommand(common.Cmd{Name: "GET", Args: []string{"tenant"}}))
 	// Output:
 	// [43 80 79 78 71 13 10] <nil>
-	// [43 104 101 108 108 111 13 10] <nil>
+	// [36 53 13 10 104 101 108 108 111 13 10] <nil>
 	// [43 79 75 13 10] <nil>
-	// [43 65 67 77 69 13 10] <nil>
+	// [36 52 13 10 65 67 77 69 13 10] <nil>
 }


### PR DESCRIPTION
## Implementation
  - Add KEYS with glob pattern matching (* ? [...]) using path.Match.
  - Expired keys are excluded from results. Returns a RESP bulk string array.
  - Fix GET and ECHO to return Bulk String ($len\r\nvalue\r\n) instead of Simple String (+value\r\n), matching the RESP spec. Add RespBulkString, RespNullBulkString, and RespBulkStringArray helpers to common/resp.go.

# Issue
#26 