### PR TITLE
refactor(common): move RESP type constants from resp to common package

### DIFF
--- a/common/grammar.go
+++ b/common/grammar.go
@@ -1,0 +1,8 @@
+package common
+
+// RESP data type names
+const SimpleString = "SIMPLE_STRING"
+const SimpleError = "SIMPLE_ERROR"
+const Integer = "INTEGER"
+const BulkString = "BULK_STRING"
+const Array = "ARRAY"

--- a/resp/grammar.go
+++ b/resp/grammar.go
@@ -2,18 +2,12 @@ package resp
 
 import "HelixDB/common"
 
-const SimpleString = "SIMPLE_STRING"
-const SimpleError = "SIMPLE_ERROR"
-const Integer = "INTEGER"
-const BulkString = "BULK_STRING"
-const Array = "ARRAY"
-
 var DataTypeToFirstByteMap = map[string]string{
-	"+": SimpleString,
-	"-": SimpleError,
-	":": Integer,
-	"$": BulkString,
-	"*": Array,
+	"+": common.SimpleString,
+	"-": common.SimpleError,
+	":": common.Integer,
+	"$": common.BulkString,
+	"*": common.Array,
 }
 
 var FirstByteToDataTypeMap = common.ReverseMap(DataTypeToFirstByteMap)

--- a/resp/parser.go
+++ b/resp/parser.go
@@ -24,7 +24,7 @@ func ParseCommand(command []byte) (common.Cmd, error) {
 		return common.Cmd{}, UnsupportedCommandDataTypeError
 	}
 	data := strings.Split(string(command), common.Terminator)
-	if dataType == Array {
+	if dataType == common.Array {
 		return parseArray(data)
 	}
 	return common.Cmd{}, nil


### PR DESCRIPTION
## Implementation
Moves SimpleString, SimpleError, Integer, BulkString, and Array constants to common/grammar.go so any package can reference RESP type names without importing resp. Parsing maps stay in resp as they are an implementation detail of the parser.

## Issue
#47 