### PR TITLE
fix(cmd): make SET options and CONFIG subcommands case-insensitive

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,6 +4,7 @@ import (
 	"HelixDB/common"
 	"HelixDB/db"
 	"errors"
+	"strings"
 )
 
 var ErrUnknownSubcommand = errors.New("unknown subcommand")
@@ -18,7 +19,8 @@ func ConfigCmd(command common.Cmd) ([]byte, error) {
 		return common.RespError(err.Error()), err
 	}
 
-	subcommand := command.Args[0]
+	// Uppercase for case-insensitive matching — subcommands are case-insensitive.
+	subcommand := strings.ToUpper(command.Args[0])
 
 	switch subcommand {
 	case "GET":

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -27,6 +27,8 @@ func TestConfigGet(t *testing.T) {
 		{common.Cmd{Name: "CONFIG", Args: []string{"GET", "unknown"}}, common.RespError("unknown config parameter 'unknown'"), ErrUnknownConfigParam},
 		// Wrong number of arguments
 		{common.Cmd{Name: "CONFIG", Args: []string{"GET"}}, common.RespError("wrong number of arguments for 'config' command"), common.ErrWrongNumberOfArgs},
+		// Case-insensitive subcommand
+		{common.Cmd{Name: "CONFIG", Args: []string{"get", "hz"}}, common.RespBulkStringArray([]string{"hz", "1"}), nil},
 	}
 	for _, test := range tests {
 		got, gotErr := ConfigCmd(test.command)
@@ -54,6 +56,8 @@ func TestConfigSet(t *testing.T) {
 		{common.Cmd{Name: "CONFIG", Args: []string{"SET", "unknown", "value"}}, common.RespError("invalid value for config parameter 'unknown'"), ErrInvalidConfigValue},
 		// Wrong number of arguments
 		{common.Cmd{Name: "CONFIG", Args: []string{"SET", "hz"}}, common.RespError("wrong number of arguments for 'config' command"), common.ErrWrongNumberOfArgs},
+		// Case-insensitive subcommand
+		{common.Cmd{Name: "CONFIG", Args: []string{"set", "hz", "10"}}, []byte("+OK\r\n"), nil},
 	}
 	for _, test := range tests {
 		got, gotErr := ConfigCmd(test.command)
@@ -64,9 +68,20 @@ func TestConfigSet(t *testing.T) {
 }
 
 func TestConfigUnknownSubcommand(t *testing.T) {
-	got, gotErr := ConfigCmd(common.Cmd{Name: "CONFIG", Args: []string{"REWRITE"}})
-	if !reflect.DeepEqual(got, common.RespError("unknown subcommand 'REWRITE' for 'config' command")) || !errors.Is(gotErr, ErrUnknownSubcommand) {
-		t.Errorf("ConfigCmd REWRITE = %v, %v; want error response, ErrUnknownSubcommand", got, gotErr)
+	tests := []struct {
+		command common.Cmd
+		want    []byte
+	}{
+		// Uppercase unknown subcommand
+		{common.Cmd{Name: "CONFIG", Args: []string{"REWRITE"}}, common.RespError("unknown subcommand 'REWRITE' for 'config' command")},
+		// Lowercase unknown subcommand — uppercased before error message
+		{common.Cmd{Name: "CONFIG", Args: []string{"rewrite"}}, common.RespError("unknown subcommand 'REWRITE' for 'config' command")},
+	}
+	for _, test := range tests {
+		got, gotErr := ConfigCmd(test.command)
+		if !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, ErrUnknownSubcommand) {
+			t.Errorf("ConfigCmd(%v) = %v, %v; want %v, ErrUnknownSubcommand", test.command, got, gotErr, test.want)
+		}
 	}
 }
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -37,10 +38,8 @@ func Set(command common.Cmd) ([]byte, error) {
 	key, value := command.Args[0], command.Args[1]
 
 	argsMap, err := parseSetArgs(command.Args)
-	if err != nil && errors.Is(err, SyntaxError) {
-		return common.RespError("syntax error"), SyntaxError
-	} else if err != nil {
-		return common.RespError("error"), err
+	if err != nil {
+		return common.RespError(err.Error()), err
 	}
 
 	// GET — capture old value before making any changes.
@@ -100,7 +99,8 @@ func parseSetArgs(args []string) (map[string]any, error) {
 	result := make(map[string]any)
 
 	for i := 0; i < len(extraArgs); {
-		arg := extraArgs[i]
+		// Uppercase for case-insensitive matching — Redis options are case-insensitive.
+		arg := strings.ToUpper(extraArgs[i])
 		if flagArgs[arg] {
 			if _, exists := result[arg]; exists {
 				return nil, SyntaxError

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -58,6 +58,11 @@ func TestSet(t *testing.T) {
 		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "NX", "XX"}}, []byte("-syntax error\r\n"), SyntaxError},
 		// EX and KEEPTTL together — mutually exclusive
 		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "EX", "10", "KEEPTTL"}}, []byte("-syntax error\r\n"), SyntaxError},
+		// Case-insensitive options
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "ex", "10"}}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "px", "5000"}}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "SET", Args: []string{"ci_nx_key", "ACME", "nx"}}, []byte("+OK\r\n"), nil},
+		{common.Cmd{Name: "SET", Args: []string{"tenant", "ACME", "keepttl"}}, []byte("+OK\r\n"), nil},
 	}
 	for _, test := range tests {
 		if got, gotErr := Set(test.command); !reflect.DeepEqual(got, test.want) || !errors.Is(gotErr, test.wantErr) {


### PR DESCRIPTION
Issue: #48 